### PR TITLE
Add turbulent load generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 */.mypy_cache/*
+beam_fem/target/

--- a/beam_fem/Cargo.lock
+++ b/beam_fem/Cargo.lock
@@ -22,6 +22,8 @@ name = "beam_fem"
 version = "0.1.0"
 dependencies = [
  "nalgebra",
+ "rand",
+ "rand_distr",
 ]
 
 [[package]]
@@ -29,6 +31,35 @@ name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "matrixmultiply"
@@ -102,6 +133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -109,6 +141,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -126,6 +167,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -180,6 +261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wide"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,4 +274,24 @@ checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/beam_fem/Cargo.toml
+++ b/beam_fem/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2024"
 
 [dependencies]
 nalgebra = { version = "0.32", features = ["std"] }
+rand = "0.8"
+rand_distr = "0.4"

--- a/beam_fem/examples/turbulent_load.rs
+++ b/beam_fem/examples/turbulent_load.rs
@@ -1,0 +1,8 @@
+use beam_fem::turbulence::generate_turbulent_loads;
+
+fn main() {
+    let loads = generate_turbulent_loads(1.0, 2.0, 5.0, 0.05, 3, 20);
+    for (i, step) in loads.iter().enumerate().take(3) {
+        println!("step {i}: {step:?}");
+    }
+}

--- a/beam_fem/src/lib.rs
+++ b/beam_fem/src/lib.rs
@@ -1,4 +1,6 @@
 use nalgebra::{DMatrix, DVector, SymmetricEigen};
+pub mod turbulence;
+pub use turbulence::generate_turbulent_loads;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Node {

--- a/beam_fem/src/turbulence.rs
+++ b/beam_fem/src/turbulence.rs
@@ -1,0 +1,82 @@
+//! Simple utilities to generate turbulent line forces.
+//!
+//! The generated field is a random process with optional spatial
+//! smoothing (controlled by the correlation length) and a basic
+//! temporal filter to limit the highest frequency content.
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use rand_distr::{Distribution, Normal};
+
+/// Generate a time history of turbulent line forces.
+///
+/// * `amplitude` - standard deviation of the force per node
+/// * `correlation_length` - spatial correlation length in number of nodes
+/// * `freq_cutoff` - upper frequency cutoff in Hz for a first-order low pass
+/// * `dt` - time step in seconds
+/// * `nodes` - number of nodes along the beam
+/// * `steps` - number of time steps
+pub fn generate_turbulent_loads(
+    amplitude: f64,
+    correlation_length: f64,
+    freq_cutoff: f64,
+    dt: f64,
+    nodes: usize,
+    steps: usize,
+) -> Vec<Vec<f64>> {
+    let mut rng = StdRng::seed_from_u64(0);
+    let normal = Normal::new(0.0, amplitude).unwrap();
+    let mut data = vec![vec![0.0; nodes]; steps];
+
+    // spatial smoothing window size (in nodes)
+    let corr = correlation_length.max(0.0).round() as usize;
+
+    // coefficient for simple exponential low-pass filter
+    let alpha = (-2.0 * std::f64::consts::PI * freq_cutoff * dt).exp();
+
+    // generate uncorrelated noise first
+    for t in 0..steps {
+        for n in 0..nodes {
+            data[t][n] = normal.sample(&mut rng);
+        }
+    }
+
+    // spatial smoothing using moving average
+    if corr > 1 {
+        for t in 0..steps {
+            let mut smoothed = vec![0.0; nodes];
+            for i in 0..nodes {
+                let start = i.saturating_sub(corr);
+                let end = (i + corr + 1).min(nodes);
+                smoothed[i] = data[t][start..end].iter().sum::<f64>() / (end - start) as f64;
+            }
+            data[t] = smoothed;
+        }
+    }
+
+    // temporal low-pass filter
+    if freq_cutoff > 0.0 {
+        for n in 0..nodes {
+            let mut state = 0.0;
+            for t in 0..steps {
+                state = alpha * state + (1.0 - alpha) * data[t][n];
+                data[t][n] = state;
+            }
+        }
+    }
+
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shape() {
+        let out = generate_turbulent_loads(1.0, 2.0, 5.0, 0.1, 4, 10);
+        assert_eq!(out.len(), 10);
+        assert_eq!(out[0].len(), 4);
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle turbulent load generation with a new module
- expose `generate_turbulent_loads` function
- demo the generator in a new example
- ignore cargo build dir

## Testing
- `cargo test`
- `cargo run --example turbulent_load`

------
https://chatgpt.com/codex/tasks/task_e_6843de6f88fc8324afecba6129fb7014